### PR TITLE
Added an option to turn off arrow

### DIFF
--- a/jquery.tipTip.js
+++ b/jquery.tipTip.js
@@ -32,6 +32,7 @@
 			fadeOut: 200,
 			attribute: "title",
 			content: false, // HTML or String to fill TipTIp with
+			arrow: true,
 		  	enter: function(){},
 		  	exit: function(){}
 	  	};
@@ -175,6 +176,12 @@
 					}
 					tiptip_arrow.css({"margin-left": arrow_left+"px", "margin-top": arrow_top+"px"});
 					tiptip_holder.css({"margin-left": marg_left+"px", "margin-top": marg_top+"px"}).attr("class","tip"+t_class);
+					
+					if(opts.arrow){
+						tiptip_arrow.show();
+					} else {
+						tiptip_arrow.hide();
+					}
 					
 					if (timeout){ clearTimeout(timeout); }
 					timeout = setTimeout(function(){ tiptip_holder.stop(true,true).fadeIn(opts.fadeIn); }, opts.delay);	


### PR DESCRIPTION
In our usage of the tiptip we needed a way to turn off the arrow.  I added a way to handle this.  Please note that I did not minify the js and update the minified version.  

Usage:

`$('.tiptip').tipTip({ arrow: false }); // turns off arrow`
