### PR TITLE
Prevent tipTip to activate when source element is not anymore attached

### DIFF
--- a/jquery.tipTip.js
+++ b/jquery.tipTip.js
@@ -177,7 +177,12 @@
 					tiptip_holder.css({"margin-left": marg_left+"px", "margin-top": marg_top+"px"}).attr("class","tip"+t_class);
 					
 					if (timeout){ clearTimeout(timeout); }
-					timeout = setTimeout(function(){ tiptip_holder.stop(true,true).fadeIn(opts.fadeIn); }, opts.delay);	
+					timeout = setTimeout(function() {
+						tiptip_holder.stop(true,true);
+						if ($.contains(document.documentElement, org_elem[0])) {
+							tiptip_holder.fadeIn(opts.fadeIn);
+						}
+					}, opts.delay);
 				}
 				
 				function deactive_tiptip(){


### PR DESCRIPTION
Eg: If you have a tipTip hovering on a button and the click event on the button will result in removing the button itself, the tipTip will be activated but the mouseLeave will never be triggered because the button element is not attached in the DOM anymore.

This is fixed by checking if the source element is still attached to the DOM before activating the tipTip
