### PR TITLE
Tooltips are sometimes left hanging

### DIFF
--- a/jquery.tipTip.js
+++ b/jquery.tipTip.js
@@ -176,11 +176,16 @@
 					tiptip_arrow.css({"margin-left": arrow_left+"px", "margin-top": arrow_top+"px"});
 					tiptip_holder.css({"margin-left": marg_left+"px", "margin-top": marg_top+"px"}).attr("class","tip"+t_class);
 					
+					$(document)
+					.unbind("click.tipTip").bind("click.tiptip", deactive_tiptip)
+					.unbind("dblclick.tipTip").bind("dblclick.tiptip", deactive_tiptip);
+					
 					if (timeout){ clearTimeout(timeout); }
 					timeout = setTimeout(function(){ tiptip_holder.stop(true,true).fadeIn(opts.fadeIn); }, opts.delay);	
 				}
 				
 				function deactive_tiptip(){
+					$(document).unbind("click.tipTip").unbind("dblclick.tipTip");
 					opts.exit.call(this);
 					if (timeout){ clearTimeout(timeout); }
 					tiptip_holder.fadeOut(opts.fadeOut);


### PR DESCRIPTION
we have a usecase like this:
- we have the tooltip on a div
- the div has an anchor in it that opens a modal

what happens is:
- the user moves over the div which opens the tooltip
- the user clicks on the anchor inside the tooltip which opens the modal
- since no mouseout occurred the tooltip is left open and due to various css issues it has a hire zindex then the modal so it is floating over the modal with no way to close it

the attached commit closes the tooltip whenever a user clicks or doubleclicks anywhere.
