### PR TITLE
Problems with width/height calculations

### DIFF
--- a/jquery.tipTip.js
+++ b/jquery.tipTip.js
@@ -10,7 +10,7 @@
  * browser tooltip. It is extremely lightweight and very smart in
  * that it detects the edges of the browser window and will make sure
  * the tooltip stays within the current window size. As a result the
- * tooltip will adjust itself to be displayed above, below, to the left 
+ * tooltip will adjust itself to be displayed above, below, to the left
  * or to the right depending on what is necessary to stay within the
  * browser window. It is completely customizable as well via CSS.
  *
@@ -21,7 +21,7 @@
 
 (function($){
 	$.fn.tipTip = function(options) {
-		var defaults = { 
+		var defaults = {
 			activation: "hover",
 			keepAlive: false,
 			maxWidth: "200px",
@@ -36,7 +36,7 @@
 		  	exit: function(){}
 	  	};
 	 	var opts = $.extend(defaults, options);
-	 	
+
 	 	// Setup tip tip elements and render them to the DOM
 	 	if($("#tiptip_holder").length <= 0){
 	 		var tiptip_holder = $('<div id="tiptip_holder" style="max-width:'+ opts.maxWidth +';"></div>');
@@ -48,7 +48,7 @@
 			var tiptip_content = $("#tiptip_content");
 			var tiptip_arrow = $("#tiptip_arrow");
 		}
-		
+
 		return this.each(function(){
 			var org_elem = $(this);
 			if(opts.content){
@@ -61,7 +61,7 @@
 					org_elem.removeAttr(opts.attribute); //remove original Attribute
 				}
 				var timeout = false;
-				
+
 				if(opts.activation == "hover"){
 					org_elem.hover(function(){
 						active_tiptip();
@@ -96,19 +96,19 @@
 						});
 					}
 				}
-			
+
 				function active_tiptip(){
 					opts.enter.call(this);
 					tiptip_content.html(org_title);
 					tiptip_holder.hide().removeAttr("class").css("margin","0");
 					tiptip_arrow.removeAttr("style");
-					
+
 					var top = parseInt(org_elem.offset()['top']);
 					var left = parseInt(org_elem.offset()['left']);
-					var org_width = parseInt(org_elem.outerWidth());
-					var org_height = parseInt(org_elem.outerHeight());
-					var tip_w = tiptip_holder.outerWidth();
-					var tip_h = tiptip_holder.outerHeight();
+					var org_width = parseInt(org_elem.outerWidth(true));
+					var org_height = parseInt(org_elem.outerHeight(true));
+					var tip_w = tiptip_holder.outerWidth(true);
+					var tip_h = tiptip_holder.outerHeight(true);
 					var w_compare = Math.round((org_width - tip_w) / 2);
 					var h_compare = Math.round((org_height - tip_h) / 2);
 					var marg_left = Math.round(left + w_compare);
@@ -119,17 +119,17 @@
 
                     if(opts.defaultPosition == "bottom"){
                     	t_class = "_bottom";
-                   	} else if(opts.defaultPosition == "top"){ 
+                   	} else if(opts.defaultPosition == "top"){
                    		t_class = "_top";
                    	} else if(opts.defaultPosition == "left"){
                    		t_class = "_left";
                    	} else if(opts.defaultPosition == "right"){
                    		t_class = "_right";
                    	}
-					
+
 					var right_compare = (w_compare + left) < parseInt($(window).scrollLeft());
 					var left_compare = (tip_w + left) > parseInt($(window).width());
-					
+
 					if((right_compare && w_compare < 0) || (t_class == "_right" && !left_compare) || (t_class == "_left" && left < (tip_w + opts.edgeOffset + 5))){
 						t_class = "_right";
 						arrow_top = Math.round(tip_h - 13) / 2;
@@ -146,7 +146,7 @@
 
 					var top_compare = (top + org_height + opts.edgeOffset + tip_h + 8) > parseInt($(window).height() + $(window).scrollTop());
 					var bottom_compare = ((top + org_height) - (opts.edgeOffset + tip_h + 8)) < 0;
-					
+
 					if(top_compare || (t_class == "_bottom" && top_compare) || (t_class == "_top" && !bottom_compare)){
 						if(t_class == "_top" || t_class == "_bottom"){
 							t_class = "_top";
@@ -161,31 +161,31 @@
 						} else {
 							t_class = t_class+"_bottom";
 						}
-						arrow_top = -12;						
+						arrow_top = -12;
 						marg_top = Math.round(top + org_height + opts.edgeOffset);
 					}
-				
+
 					if(t_class == "_right_top" || t_class == "_left_top"){
 						marg_top = marg_top + 5;
-					} else if(t_class == "_right_bottom" || t_class == "_left_bottom"){		
+					} else if(t_class == "_right_bottom" || t_class == "_left_bottom"){
 						marg_top = marg_top - 5;
 					}
-					if(t_class == "_left_top" || t_class == "_left_bottom"){	
+					if(t_class == "_left_top" || t_class == "_left_bottom"){
 						marg_left = marg_left + 5;
 					}
 					tiptip_arrow.css({"margin-left": arrow_left+"px", "margin-top": arrow_top+"px"});
 					tiptip_holder.css({"margin-left": marg_left+"px", "margin-top": marg_top+"px"}).attr("class","tip"+t_class);
-					
+
 					if (timeout){ clearTimeout(timeout); }
-					timeout = setTimeout(function(){ tiptip_holder.stop(true,true).fadeIn(opts.fadeIn); }, opts.delay);	
+					timeout = setTimeout(function(){ tiptip_holder.stop(true,true).fadeIn(opts.fadeIn); }, opts.delay);
 				}
-				
+
 				function deactive_tiptip(){
 					opts.exit.call(this);
 					if (timeout){ clearTimeout(timeout); }
 					tiptip_holder.fadeOut(opts.fadeOut);
 				}
-			}				
+			}
 		});
 	}
-})(jQuery);  	
+})(jQuery);


### PR DESCRIPTION
When implementing Tiptip in my client's site, the element was appearing right in the top-left corner, and this was being caused by the margin calculation failing.

I debugged and traced it back to the outerWidth() and outerHeight() calls, which were returning elements instead of values. Forcing them to calculate the margin too (using the parameter) gets rid of this bug.
