### PR TITLE
Adding SVG Support

### DIFF
--- a/jquery.tipTip.js
+++ b/jquery.tipTip.js
@@ -105,8 +105,8 @@
 					
 					var top = parseInt(org_elem.offset()['top']);
 					var left = parseInt(org_elem.offset()['left']);
-					var org_width = parseInt(org_elem.outerWidth());
-					var org_height = parseInt(org_elem.outerHeight());
+					var org_width = parseInt(org_elem[0].getBoundingClientRect().width);
+					var org_height = parseInt(org_elem[0].getBoundingClientRect().height);
 					var tip_w = tiptip_holder.outerWidth();
 					var tip_h = tiptip_holder.outerHeight();
 					var w_compare = Math.round((org_width - tip_w) / 2);


### PR DESCRIPTION
When using jquery.tiptip on SVG elements in Chrome, the tooltip appears in the top-left corner of the element instead of in the middle. In Firefox, the tooltip appears at the top of the page, nowhere near the element in question. This is caused because the jQuery method outerWidth() doesn't work with SVG. This patch uses getBoundingClientRect instead. Couldn't find any issues with normal links with a quick test.

'Some more infos on getBoundingClientRect'
Browser support: https://developer.mozilla.org/en-US/docs/Web/API/Element.getBoundingClientRect
getBoundingClientRect is Awesome: http://ejohn.org/blog/getboundingclientrect-is-awesome/
